### PR TITLE
Post(投稿)のSeederとマイグレーション作成

### DIFF
--- a/app/Post.php
+++ b/app/Post.php
@@ -1,0 +1,13 @@
+<?php
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class Post extends Model
+{
+    use SoftDeletes;
+    public function user(){
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -38,4 +38,9 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    public function posts()
+    {
+        return $this->hasMany(Posts::class);
+    }
 }

--- a/database/migrations/2024_08_09_191704_create_posts_table.php
+++ b/database/migrations/2024_08_09_191704_create_posts_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePostsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('text');
+            $table->bigInteger('user_id')->unsigned()->index();
+            $table->timestamps();
+            $table->softDeletes();
+            // 外部キー制約
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('posts');
+    }
+}

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -12,5 +12,6 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         $this->call(UsersTableSeeder::class);
+        $this->call(PostsTableSeeder::class);
     }
 }

--- a/database/seeds/PostsTableSeeder.php
+++ b/database/seeds/PostsTableSeeder.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class PostsTableSeeder extends Seeder
+{
+    /**
+     * Seed the application's database.
+     *
+     * @return void
+     */
+    public function run()
+    {
+        for ($val = 0; $val <= 9; $val++) {
+            DB::table('posts')->insert([
+                'text' => 'test' . $val,
+                'user_id' => $val + 1,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
### issue
https://github.com/Hashimoto-Noriaki/laravel-vue.js-chatwork-app/issues/4#issue-2457310324

### 変更点
⚫︎モデル
- app/Post.php
- app/User.php

⚫︎マイグレーション
- database/migrations/2024_08_09_191704_create_posts_table.php

⚫︎シーダー
- database/seeds/DatabaseSeeder.php
- database/seeds/PostsTableSeeder.php

### コマンド
- postsテーブル作成
```
 php artisan make:migration create_posts_table --create=posts
```

- postモデル作成
```
 php artisan make:model Post
```
- postシーダー作成
```
 php artisan make:seeder PostsTableSeeder
```

- Userモデル
ユーザーモデルに1対多でPostモデルを紐付け

マイグレーション実行
```
php artisan migrate
```


### マイグレーション補足
```php
$table->bigInteger('user_id')->unsigned()->index();
```
bigInteger メソッドは、BIGINT 型のカラムを作成。
user_id という名前が付けられ、unsigned として設定。unsigned は負の値を許容しないこと。
index メソッドは、user_id カラムにインデックスを追加。これにより、クエリの検索性能が向上。

```php
$table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
```
foreign メソッドは、user_id カラムに外部キー制約を追加。
references('id') は、users テーブルの id カラムを参照することを指定。
on('users') は、外部キーが users テーブルの id カラムに関連付けられていることを指定。
onDelete('cascade') は、users テーブルの関連するレコードが削除された場合に、そのレコードに関連する posts テーブルのレコードも自動的に削除されるように指定します。これを「カスケード削除」


### 動作確認

<img width="890" alt="スクリーンショット 2024-08-09 19 55 27" src="https://github.com/user-attachments/assets/3b7e97be-5f9b-4351-af4f-89f02bc8bb09">
