### PR TITLE
新規登録作成

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -29,7 +29,7 @@ class RegisterController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = RouteServiceProvider::HOME;
+    protected $redirectTo = "/";
 
     /**
      * Create a new controller instance.

--- a/app/Http/Middleware/RedirectIfAuthenticated.php
+++ b/app/Http/Middleware/RedirectIfAuthenticated.php
@@ -19,7 +19,7 @@ class RedirectIfAuthenticated
     public function handle($request, Closure $next, $guard = null)
     {
         if (Auth::guard($guard)->check()) {
-            return redirect(RouteServiceProvider::HOME);
+            return redirect("/");
         }
 
         return $next($request);

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.app')
+@section('content')
+
+<div class="text-center mt-5">
+    <div class="text-center">
+        <h1><i class="fas fa-chalkboard-teacher pr-3 d-inline"></i>Chat App</h1>
+        <div class="text-center mt-3">
+            <h3 class="login_title text-left d-inline-block mt-10">新規登録する</h3>
+        </div>
+        <div class="row mt-50 mb-5">
+            <div class="col-sm-4 offset-sm-4">
+                <form method="POST" action="{{ route('signup.post') }}">
+                    @csrf
+                    <div class="form-group">
+                        <label for="name">名前</label>
+                        <input id="name" type="text" class="form-control" name="name" value="{{ old('name') }}">
+                    </div>
+                    <div class="form-group">
+                        <label for="email">メールアドレス</label>
+                        <input id="email" type="text" class="form-control" name="email" value="{{ old('email') }}">
+                    </div>
+                    <div class="form-group">
+                        <label for="password">パスワード</label>
+                        <input id="password" type="password" class="form-control" name="password" value="{{ old('password') }}">
+                    </div>
+                    <div class="form-group">
+                        <label for="password_confirmation">パスワード確認</label>
+                        <input id="password_confirmation" type="password" class="form-control" name="password_confirmation" value="{{ old('password_confirmation') }}">
+                    </div>
+                    <button type="submit" class="btn btn-block btn-primary mt-3">新規登録</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/commons/header.blade.php
+++ b/resources/views/commons/header.blade.php
@@ -8,7 +8,7 @@
             <div class="container navbar-container" id="nav-bar" >
                 <ul class="navbar-nav ml-auto">
                     <li class="nav-item"><a href="" class="nav-link">ログイン</a></li>
-                    <li class="nav-item"><a href="" class="nav-link">新規登録</a></li>
+                    <li class="nav-item"><a href="{{ route('signup') }}" class="nav-link">新規登録</a></li>
                 </ul>
             </div>
         </nav>

--- a/routes/web.php
+++ b/routes/web.php
@@ -14,3 +14,7 @@
 Route::get('/', function () {
     return view('welcome');
 });
+
+//新規登録
+Route::get('signup','Auth\RegisterController@showRegistrationForm')->name('signup');
+Route::post('signup','Auth\RegisterController@register')->name('signup.post');


### PR DESCRIPTION
### issue
https://github.com/Hashimoto-Noriaki/laravel-vue.js-chatwork-app/issues/21#issue-2458273241

### 変更点
- app/Http/Controllers/Auth/RegisterController.php
- app/Http/Middleware/RedirectIfAuthenticated.php
- resources/views/auth/register.blade.php
- resources/views/commons/header.blade.php
- routes/web.php

### 動作確認
1. 下記の新規登録の画面から新規登録をする

<img width="1425" alt="スクリーンショット 2024-08-10 0 58 48" src="https://github.com/user-attachments/assets/31ed8057-6b41-46d2-8d16-6013656c62bd">

2.完成画面から登録ができることを確認

<img width="1440" alt="スクリーンショット 2024-08-10 1 21 42" src="https://github.com/user-attachments/assets/475930c4-449a

### ユーザー登録の確認
犬で登録

<img width="452" alt="スクリーンショット 2024-08-10 1 22 46" src="https://github.com/user-attachments/assets/041293db-f92a-4a62-a2f4-8d125ded5c64">
-4c20-a3b3-218130d74f14">

### 登録後
このissueをマージする段階では、まだログイン機能を作っていないので、ログアウトができない状態なので、
Adminerから手動で削除すると再度新規登録ができる。

### 補足
- ```app/Http/Middleware/RedirectIfAuthenticated.php```
このミドルウェアは、例えば認証済みのユーザーがログインページや新規ユーザー登録ページにアクセスしようとしたときに、それを防いでホームページなどの他のページにリダイレクトします。これにより、既にログインしているユーザーが再度ログインしようとする無駄な操作を防ぐことができます。

- ```csrf```
***form 開始タグの直後にある「@csrf」***
クロス・サイト・リクエスト・フォージェリ（CSRF）というハッキングの手口からサイトを守るための記述。

ex)
POSTメソッドなどで他の悪意あるサーバからリクエストがあった場合、Laravelがそのリクエストを正しいものと見なさないための必須の記述

