### PR TITLE
ユーザーの退会機能

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -39,4 +39,13 @@ class UsersController extends Controller
         $user->save();
         return redirect()->route('users.show',$user->id);
     }
+
+    function destroy($id)
+    {
+        $user = User::findOrFail($id);
+        if (\Auth::id() === $user->id) {
+            $user->delete();
+        }
+        return redirect('/');
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -39,8 +39,21 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
     ];
 
+    // protected $dates = [
+    //     'deleted_at'
+    // ];
+
     public function posts()
     {
         return $this->hasMany(Posts::class);
     }
+
+    // public static function boot()
+    // {
+    //     parent::boot();
+
+    //     static::deleting(function ($user) {
+    //         $user->posts()->delete();
+    //     });
+    // }
 }

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -22,8 +22,32 @@
             <input id="password_confirmation" type="password" class="form-control" name="password_confirmation" value="{{ old('password_confirmation') }}">
         </div>
         <div class="d-flex justify-content-between">
-            <button type="submit" class="mt-3 btn btn-danger ">退会する</button>
+            <a href="#" data-toggle="modal" data-target="#delete-modal" class="btn btn-danger align-self-end">退会する</a>
             <button type="submit"class="mt-3 btn btn-success">更新する</a></button>
         </div>
     </form>
+
+    <div class="modal fade" id="delete-modal" tabindex="-1" role="dialog" aria-labelledby="delete-modal-label">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h4 class="modal-title">確認</h4>
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </div>
+                <div class="modal-body">
+                    <form method="POST" action="{{ route('users.delete', $user->id) }}">
+                        @csrf
+                        @method('DELETE')
+                        <label>本当に退会しますか。</label>
+                        <div class="modal-footer justify-content-between">
+                            <button type="submit" id="delete-button" class="btn btn-danger">退会する</button>
+                            <button type="button" class="btn btn-secondary" data-dismiss="modal">閉じる</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,9 +24,10 @@ Route::get('login', 'Auth\LoginController@showLoginForm')->name('login');
 Route::post('login', 'Auth\LoginController@login')->name('login.post');
 Route::get('logout', 'Auth\LoginController@logout')->name('logout');
 
-//ユーザー詳細、編集、更新
+//ユーザー詳細、編集、更新、削除
 Route::prefix('users')->group(function() {
     Route::get('{id}','UsersController@show')->name('users.show');
     Route::get('{id}/edit','UsersController@edit')->name('users.edit');
     Route::put('{id}','UsersController@update')->name('users.update');
+    Route::delete('{id}','UsersController@destroy')->name('users.delete');
 });


### PR DESCRIPTION
### issue
https://github.com/Hashimoto-Noriaki/laravel-vue.js-chatwork-app/issues/28#issue-2458346644

### 変更点
- app/Http/Controllers/UsersController.php
- app/User.php
- resources/views/users/edit.blade.php
- routes/web.php

### 動作確認
1. localhost:3000/users/12/edit

<img width="1437" alt="スクリーンショット 2024-08-11 23 53 35" src="https://github.com/user-attachments/assets/7345f508-eb77-4a84-80bf-d0083afd1473">

2 退会ボタンを押すとモーダルが出てくる

<img width="1439" alt="スクリーンショット 2024-08-11 23 56 52" src="https://github.com/user-attachments/assets/241129d3-5c1c-4b4c-b87f-8ae0beee6b71">

3  元々の情報
<img width="746" alt="スクリーンショット 2024-08-11 23 53 41" src="https://github.com/user-attachments/assets/636766df-ca4

4  削除の確認

<img width="746" alt="スクリーンショット 2024-08-11 23 53 41" src="https://github.com/user-attachments/assets/effef328-7e71-49fd-96ef-0a0bb215b270">
d-4e2d-ab59-31d724007511">

5 削除後の画面(ホーム画面に潜る)

<img width="1440" alt="スクリーンショット 2024-08-11 23 57 06" src="https://github.com/user-attachments/assets/65598019-0625-4184-907a-6fb1a06b30bf">

















