### PR TITLE
新規登録画面からログイン画面に遷移するようにする

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -29,6 +29,12 @@
                     </div>
                     <button type="submit" class="btn btn-block btn-primary mt-3">新規登録</button>
                 </form>
+
+                <div class = "text-center mt-3">
+                    <p><a href = "{{ route('login') }}">すでに登録されている方はこちら</a></p>
+
+                    </p>
+                <div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
### issue

https://github.com/Hashimoto-Noriaki/laravel-vue.js-chatwork-app/issues/24#issue-2458329728

### 変更点
- resources/views/auth/register.blade.php

### 動作確認
すでに登録されている方はこちらをクリックするとログイン画面に遷移される

<img width="1440" alt="スクリーンショット 2024-08-12 0 50 59" src="https://github.com/user-attachments/assets/90c969c1-c725-4f17-8b6d-d8a076a4116e">

