### PR TITLE
ユーザー詳細画面から投稿詳細画面に戻れるようにする

### DIFF
--- a/resources/views/commons/user_details_card.blade.php
+++ b/resources/views/commons/user_details_card.blade.php
@@ -11,6 +11,3 @@
         @endif
     </div>
 </div><br>
-<div class = "text-center mt-3">
-    <p><a href = "{{ route('posts.index') }}">ホーム画面はこちら</a></p>
-</div>

--- a/resources/views/commons/user_details_card.blade.php
+++ b/resources/views/commons/user_details_card.blade.php
@@ -11,3 +11,6 @@
         @endif
     </div>
 </div><br>
+<div class = "text-center mt-3">
+    <p><a href = "{{ route('posts.index') }}">ホーム画面はこちら</a></p>
+</div>

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -19,4 +19,7 @@
         @include('post.post', ['posts' => $posts])
     </div>
 </div>
+<div class = "text-center mt-3">
+    <p><a href = "{{ route('posts.index') }}">ホーム画面はこちら</a></p>
+</div>
 @endsection


### PR DESCRIPTION
### issue
https://github.com/Hashimoto-Noriaki/laravel-vue.js-chatwork-app/issues/61#issue-2470074771

### 変更点


### 動作確認
ホーム画面へのリンクを押すと投稿一覧に遷移する

<img width="1216" alt="スクリーンショット 2024-08-19 23 05 59" src="https://github.com/user-attachments/assets/a793bb9a-ba91-4986-a82d-42e179494fc5">
